### PR TITLE
Adapt w.r.t. coq/coq#15008.

### DIFF
--- a/language-server/dm/executionManager.ml
+++ b/language-server/dm/executionManager.ml
@@ -116,7 +116,7 @@ let interp_ast ~doc_id ~state_id vernac_st ast =
 (* This adapts the Future API with our event model *)
 let interp_qed_delayed ~state_id vernac_st =
   let f proof =
-    let fix_exn x = x in (* FIXME *)
+    let fix_exn = None in (* FIXME *)
     let f, assign = Future.create_delegate ~blocking:false ~name:"XX" fix_exn in
     Declare.Proof.close_future_proof ~feedback_id:state_id proof f, assign
   in


### PR DESCRIPTION
I had to make the delegated future blocking, when it was non-blocking before. I am unsure this is correct, but I believe this does not matter because the STM will never force the underlying proof. In any case, if that happened, there is no handler in the whole repo for the (removed by coq/coq#1508) `NotReady` exception so this would just result in an uncaught exception in the end. Hence, this patch cannot make things worse.